### PR TITLE
docker-compose.yml内 apiとfrontの変数をDockerfileに移動

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,6 +2,7 @@ FROM node:16
 ARG API_WORKDIR
 WORKDIR ${API_WORKDIR}
 # ENV DOCKERIZE_VERSION v0.6.1
+ENV TZ Asia/Tokyo
 RUN apt update
 RUN apt install -y wget vim
 RUN echo "set encoding=utf-8" >> ~/.vimrc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@ services:
         - FRONT_WORKDIR=$FRONT_WORKDIR
     tty: true
     stdin_open: true
-    environment:
-      TZ: Asia/Tokyo
     volumes:
       - ./front:$FRONT_WORKDIR
     ports:
@@ -38,8 +36,6 @@ services:
         - API_WORKDIR=$API_WORKDIR
     tty: true
     stdin_open: true
-    environment:
-      TZ: Asia/Tokyo
     volumes:
       - ./api:$API_WORKDIR
     ports:

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -2,6 +2,7 @@ FROM node:16
 ARG FRONT_WORKDIR
 WORKDIR ${FRONT_WORKDIR}
 # ENV DOCKERIZE_VERSION v0.6.1
+ENV TZ Asia/Tokyo
 RUN apt update
 RUN apt install -y wget vim
 RUN echo "set encoding=utf-8" >> ~/.vimrc


### PR DESCRIPTION
docker-compose.yml内で指定していた環境変数TZを、
api,frontのDockerfile側で指定するよう改修しました。
レビュー宜しくお願いいたします。