### PR TITLE
issue「makeコマンドでのプロジェクト新規作成について 」の改修

### DIFF
--- a/HOWTOUSE.md
+++ b/HOWTOUSE.md
@@ -20,14 +20,6 @@ Makefile内コマンドを用いた諸々の操作方法は以下のとおりで
 - apiコンテナに入り作業をする: make api-exec
 - dbコンテナに入り作業をする: make db-exec
 - dbコンテナに入りつつデータベースにログイン: make db-login
+- front(React)のプロジェクト新規作成: make front-create-app
+- api(NestJS)のプロジェクト新規作成: make api-create-app
 - (注意)front,apiのimage削除、各種volume削除: make all-reset
-
-front(React)のプロジェクト作成手順は以下のとおりです。
-1. docker-compose.ymlのfront-storeのVolume-Mount設定をコメントアウト
-2. make front-build を実行
-3. docker-compose.ymlのfront-storeのVolume-Mount設定のコメントアウトを外して再起動 (3終了後は、ホスト側のnode_modulesは削除して良い)
-
-api(NestJS)のプロジェクト作成手順は以下のとおりです。
-1. docker-compose.ymlのapi-storeのVolume-Mount設定をコメントアウト
-2. make api-build を実行
-3. docker-compose.ymlのapi-storeのVolume-Mount設定のコメントアウトを外して再起動 (3終了後は、ホスト側のnode_modulesは削除して良い)

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ front-exec:
 # 	node_modules, .gitの移動は行いたくないので、移動前に削除。
 # (3)/workspace_tmpのプロジェクトから残ったファイルを/workspace/frontに移動。
 # (4)/workspace_tmpを削除
-front-build:
+front-create-app:
 	docker-compose exec front sh -c \
 		"mkdir /workspace_tmp && cd /workspace_tmp && yarn create react-app --template typescript ${FRONT_PROJ_NAME} && \
 		cd ./${FRONT_PROJ_NAME} && rm -rf .git node_modules &&\
@@ -63,7 +63,7 @@ front-build:
 # 	node_modules, .gitの移動は行いたくないので、移動前に削除。
 # (3)/workspace_tmpのプロジェクトから残ったファイルを/workspace/frontに移動。
 # (4)/workspace_tmpを削除
-# front-build:
+# front-create-app:
 # 	docker-compose exec front sh -c \
 # 		"mkdir /workspace_tmp && cd /workspace_tmp && yarn create next-app --ts ${FRONT_PROJ_NAME} && \
 # 		cd ./${FRONT_PROJ_NAME} && rm -rf .git node_modules &&\
@@ -79,7 +79,7 @@ api-exec:
 
 # NestJSプロジェクト新規作成
 # --skip-installをすることで、プロジェクト作成の際にnode_modulesがインストールされなくなり、Volume-Mountされているnode_modulesと競合せず済む。
-api-build:
+api-create-app:
 	docker-compose exec api sh -c \
 		"nest new ${API_PROJ_NAME} --package-manager yarn --skip-install"
 

--- a/Makefile
+++ b/Makefile
@@ -76,15 +76,12 @@ front-build:
 api-exec:
 	docker-compose exec api bash
 
-# NestJSプロジェクト作成
-# プロジェクト作成の前からnode_modulesのVolume-Mountがされている場合、docker-compose.ymlの該当箇所をコメントアウトするように指示する。
+# NestJSプロジェクト新規作成
+# --skip-installをすることで、プロジェクト作成の際にnode_modulesがインストールされなくなり、Volume-Mountされているnode_modulesと競合せず済む。
 api-build:
 	docker-compose exec api sh -c \
-		"if [ -d ${API_PROJ_NAME}/node_modules ]; then \
-			echo Comment out api_store Volume-Mount in docker-compose.yml ! ; \
-		else \
-			nest new ${API_PROJ_NAME} --package-manager yarn --skip-git \
-		fi"
+		"nest new ${API_PROJ_NAME} --package-manager yarn --skip-install"
+
 ########################################################################################
 ################################# dbに関するコマンド ######################################
 ########################################################################################

--- a/Makefile
+++ b/Makefile
@@ -42,33 +42,34 @@ all-reset:
 front-exec:
 	docker-compose exec front bash
 
-# Reactプロジェクト作成
-# プロジェクト作成の前からnode_modulesのVolume-Mountがされている場合、docker-compose.ymlの該当箇所をコメントアウトするように指示する。
-# プロジェクトのルート位置でgit管理しているため、Reactプロジェクト内に生成される.gitは削除する。
+# Reactプロジェクト新規作成
+# (1)/workspace/front(ホスト側の./front)のプロジェクト内のnode_modulesがVolume-Mountがされている関係上、
+# 	一時的にコンテナ内の/workspace_tmpにプロジェクトを作成、
+# (2)/workspace_tmpに作成したプロジェクトのファイルを、/workspace/frontのプロジェクトに移動させるが、
+# 	node_modules, .gitの移動は行いたくないので、移動前に削除。
+# (3)/workspace_tmpのプロジェクトから残ったファイルを/workspace/frontに移動。
+# (4)/workspace_tmpを削除
 front-build:
 	docker-compose exec front sh -c \
-		"if [ -d ${FRONT_PROJ_NAME}/node_modules ]; then \
-			echo Comment out front_store Volume-Mount in docker-compose.yml ! ; \
-		else \
-			yarn create react-app --template typescript ${FRONT_PROJ_NAME} && cd ${FRONT_PROJ_NAME} && \
-			if [ -d .git ]; then \
-				rm -rf .git ; \
-			fi\
-		fi"
+		"mkdir /workspace_tmp && cd /workspace_tmp && yarn create react-app --template typescript ${FRONT_PROJ_NAME} && \
+		cd ./${FRONT_PROJ_NAME} && rm -rf .git node_modules &&\
+		cd /workspace/front && mv /workspace_tmp/${FRONT_PROJ_NAME}/* ./${FRONT_PROJ_NAME} && \
+		rm -rf /workspace_tmp"
 
-# Next.jsプロジェクト作成
-# プロジェクト作成の前からnode_modulesのVolume-Mountがされている場合、docker-compose.ymlの該当箇所をコメントアウトするように指示する。
-# プロジェクトのルート位置でgit管理しているため、Nextプロジェクト内に生成される.gitは削除する。
+# Next.jsプロジェクト新規作成
+# (1)/workspace/front(ホスト側の./front)のプロジェクト内のnode_modulesがVolume-Mountがされている関係上、
+# 	一時的にコンテナ内の/workspace_tmpにプロジェクトを作成、
+# (2)/workspace_tmpに作成したプロジェクトのファイルを、/workspace/frontのプロジェクトに移動させるが、
+# 	node_modules, .gitの移動は行いたくないので、移動前に削除。
+# (3)/workspace_tmpのプロジェクトから残ったファイルを/workspace/frontに移動。
+# (4)/workspace_tmpを削除
 # front-build:
 # 	docker-compose exec front sh -c \
-# 		"if [ -d ${FRONT_PROJ_NAME}/node_modules ]; then \
-# 			echo Comment out front_store Volume-Mount in docker-compose.yml ! ; \
-# 		else \
-# 			yarn create next-app --ts ${FRONT_PROJ_NAME} && cd ${FRONT_PROJ_NAME} && \
-# 			if [ -d .git ]; then \
-# 				rm -rf .git ; \
-# 			fi\
-# 		fi"
+# 		"mkdir /workspace_tmp && cd /workspace_tmp && yarn create next-app --ts ${FRONT_PROJ_NAME} && \
+# 		cd ./${FRONT_PROJ_NAME} && rm -rf .git node_modules &&\
+# 		cd /workspace/front && mv /workspace_tmp/${FRONT_PROJ_NAME}/* ./${FRONT_PROJ_NAME} && \
+# 		rm -rf /workspace_tmp"
+
 ########################################################################################
 ################################# apiに関するコマンド #####################################
 ########################################################################################


### PR DESCRIPTION
従来だと、プロジェクトを新規作成する際は、docker-compose.ymlのvolume-mount部分をコメントアウトし、
プロジェクト作成先のディレクトリにnode_modulesが存在しないようにしていました(既にnode_modulesが存在するディレクトリにはreact, nestのプロジェクトを新規作成できないのが原因)。

そこで今回、react,nestのプロジェクトを新規作成するコマンド(front-build, api-build)を改修し、
docker-compose.ymlのコメントアウトが不要になるように改修しました。