### PR TITLE
issue「makeコマンドでのプロジェクト新規作成について 」の改修 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ front-create-app:
 	docker-compose exec front sh -c \
 		"mkdir /workspace_tmp && cd /workspace_tmp && yarn create react-app --template typescript ${FRONT_PROJ_NAME} && \
 		cd ./${FRONT_PROJ_NAME} && rm -rf .git node_modules &&\
-		cd /workspace/front && mv /workspace_tmp/${FRONT_PROJ_NAME}/* /workspace_tmp/${FRONT_PROJ_NAME}/.[^\.]* ./${FRONT_PROJ_NAME} && \
-		rm -rf /workspace_tmp"
+		cd /workspace_tmp/${FRONT_PROJ_NAME} && mv * .[^\.]* /workspace/front/${FRONT_PROJ_NAME} && \
+		cd /workspace/front && rm -rf /workspace_tmp"
 
 # Next.jsプロジェクト新規作成
 # (1)/workspace/front(ホスト側の./front)のプロジェクト内のnode_modulesがVolume-Mountがされている関係上、
@@ -67,8 +67,8 @@ front-create-app:
 # 	docker-compose exec front sh -c \
 # 		"mkdir /workspace_tmp && cd /workspace_tmp && yarn create next-app --ts ${FRONT_PROJ_NAME} && \
 # 		cd ./${FRONT_PROJ_NAME} && rm -rf .git node_modules &&\
-# 		cd /workspace/front && mv /workspace_tmp/${FRONT_PROJ_NAME}/* /workspace_tmp/${FRONT_PROJ_NAME}/.[^\.]* ./${FRONT_PROJ_NAME} && \
-# 		rm -rf /workspace_tmp"
+# 		cd /workspace_tmp/${FRONT_PROJ_NAME} && mv * .[^\.]* /workspace/front/${FRONT_PROJ_NAME} && \
+# 		cd /workspace/front && rm -rf /workspace_tmp"
 
 ########################################################################################
 ################################# apiに関するコマンド #####################################

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ front-create-app:
 	docker-compose exec front sh -c \
 		"mkdir /workspace_tmp && cd /workspace_tmp && yarn create react-app --template typescript ${FRONT_PROJ_NAME} && \
 		cd ./${FRONT_PROJ_NAME} && rm -rf .git node_modules &&\
-		cd /workspace/front && mv /workspace_tmp/${FRONT_PROJ_NAME}/* ./${FRONT_PROJ_NAME} && \
+		cd /workspace/front && mv /workspace_tmp/${FRONT_PROJ_NAME}/* /workspace_tmp/${FRONT_PROJ_NAME}/.[^\.]* ./${FRONT_PROJ_NAME} && \
 		rm -rf /workspace_tmp"
 
 # Next.jsプロジェクト新規作成
@@ -67,7 +67,7 @@ front-create-app:
 # 	docker-compose exec front sh -c \
 # 		"mkdir /workspace_tmp && cd /workspace_tmp && yarn create next-app --ts ${FRONT_PROJ_NAME} && \
 # 		cd ./${FRONT_PROJ_NAME} && rm -rf .git node_modules &&\
-# 		cd /workspace/front && mv /workspace_tmp/${FRONT_PROJ_NAME}/* ./${FRONT_PROJ_NAME} && \
+# 		cd /workspace/front && mv /workspace_tmp/${FRONT_PROJ_NAME}/* /workspace_tmp/${FRONT_PROJ_NAME}/.[^\.]* ./${FRONT_PROJ_NAME} && \
 # 		rm -rf /workspace_tmp"
 
 ########################################################################################


### PR DESCRIPTION
front-create-appの際、一時的に作成したプロジェクト(/workspace_tmp) のファイルを、作業用プロジェクト(/workspace/front)に移動する際、隠しファイルが移動されないという問題があり、それを改修した。