### PR TITLE
Fix api return value

### DIFF
--- a/api/nest_app/src/actions/actions.controller.ts
+++ b/api/nest_app/src/actions/actions.controller.ts
@@ -27,7 +27,7 @@ export class ActionsController {
     @Param('cycleId', ParseIntPipe) cycleId: number,
     @Param('round', ParseIntPipe) round: number,
     @Body('complete', ParseBoolPipe) complete: boolean,
-  ): Promise<void> {
-    await this.actionService.updateComplete(cycleId, round, complete);
+  ): Promise<{ complete: boolean }> {
+    return await this.actionService.updateComplete(cycleId, round, complete);
   }
 }

--- a/api/nest_app/src/actions/actions.service.ts
+++ b/api/nest_app/src/actions/actions.service.ts
@@ -10,8 +10,8 @@ export class ActionsService {
     return await this.prisma.action.findFirst({ where: { cycleId, round } });
   }
 
-  async createAction(cycleId: number, round: number): Promise<void> {
-    await this.prisma.action.create({
+  async createAction(cycleId: number, round: number): Promise<Action> {
+    return await this.prisma.action.create({
       data: {
         cycleId,
         round,
@@ -23,10 +23,11 @@ export class ActionsService {
     cycleId: number,
     round: number,
     complete: boolean,
-  ): Promise<void> {
+  ): Promise<{ complete: boolean }> {
     await this.prisma.action.updateMany({
       where: { cycleId, round },
       data: { complete },
     });
+    return { complete: (await this.findAction(cycleId, round)).complete };
   }
 }

--- a/api/nest_app/src/actions/actions.service.ts
+++ b/api/nest_app/src/actions/actions.service.ts
@@ -28,6 +28,6 @@ export class ActionsService {
       where: { cycleId, round },
       data: { complete },
     });
-    return { complete: (await this.findAction(cycleId, round)).complete };
+    return { complete: complete };
   }
 }

--- a/api/nest_app/src/checks/checks.controller.ts
+++ b/api/nest_app/src/checks/checks.controller.ts
@@ -27,7 +27,7 @@ export class ChecksController {
     @Param('cycleId', ParseIntPipe) cycleId: number,
     @Param('round', ParseIntPipe) round: number,
     @Body('complete', ParseBoolPipe) complete: boolean,
-  ): Promise<void> {
-    await this.checksService.updateComplete(cycleId, round, complete);
+  ): Promise<{ complete: boolean }> {
+    return await this.checksService.updateComplete(cycleId, round, complete);
   }
 }

--- a/api/nest_app/src/checks/checks.service.ts
+++ b/api/nest_app/src/checks/checks.service.ts
@@ -10,8 +10,8 @@ export class ChecksService {
     return await this.prisma.check.findFirst({ where: { cycleId, round } });
   }
 
-  async createCheck(cycleId: number, round: number): Promise<void> {
-    await this.prisma.check.create({
+  async createCheck(cycleId: number, round: number): Promise<Check> {
+    return await this.prisma.check.create({
       data: {
         cycleId,
         round,
@@ -23,10 +23,11 @@ export class ChecksService {
     cycleId: number,
     round: number,
     complete: boolean,
-  ): Promise<void> {
+  ): Promise<{ complete: boolean }> {
     await this.prisma.check.updateMany({
       where: { cycleId, round },
       data: { complete },
     });
+    return { complete: (await this.findCheck(cycleId, round)).complete };
   }
 }

--- a/api/nest_app/src/checks/checks.service.ts
+++ b/api/nest_app/src/checks/checks.service.ts
@@ -28,6 +28,6 @@ export class ChecksService {
       where: { cycleId, round },
       data: { complete },
     });
-    return { complete: (await this.findCheck(cycleId, round)).complete };
+    return { complete: complete };
   }
 }

--- a/api/nest_app/src/cycles/cycles.controller.ts
+++ b/api/nest_app/src/cycles/cycles.controller.ts
@@ -4,6 +4,7 @@ import {
   Delete,
   Get,
   Param,
+  ParseBoolPipe,
   ParseIntPipe,
   Post,
   Put,
@@ -89,10 +90,11 @@ export class CyclesController {
   async erase(
     @Param('id', ParseIntPipe) id: number,
     @Param('userId', ParseIntPipe) userId: number,
+    @Body('erased', ParseBoolPipe) erased: boolean,
   ): Promise<{
     erased: boolean;
   }> {
-    return await this.cyclesService.eraseOrRestore(id, userId);
+    return await this.cyclesService.eraseOrRestore(id, userId, erased);
   }
 
   // サイクルをお気に入りに登録する処理
@@ -100,10 +102,11 @@ export class CyclesController {
   async favorite(
     @Param('id', ParseIntPipe) id: number,
     @Param('userId', ParseIntPipe) userId: number,
+    @Body('favorite', ParseBoolPipe) favorite: boolean,
   ): Promise<{
     favorite: boolean;
   }> {
-    return await this.cyclesService.favorite(id, userId);
+    return await this.cyclesService.favorite(id, userId, favorite);
   }
 
   // サイクルの完全な削除

--- a/api/nest_app/src/cycles/cycles.controller.ts
+++ b/api/nest_app/src/cycles/cycles.controller.ts
@@ -51,30 +51,35 @@ export class CyclesController {
     return await this.cyclesService.findById(id, userId);
   }
 
+  // サイクルの新規作成
   @Post('create')
-  async create(@Body() cycleDto: CycleDto): Promise<void> {
+  async create(@Body() cycleDto: CycleDto): Promise<Cycle> {
     return await this.cyclesService.create(cycleDto);
   }
 
-  @Post('create-pdca/:cycleId/:round')
+  // 新しい周のP,D,C,Aのデータを作成する処理
+  // frontとの兼ね合いにより、戻り値は新しい周が入ったオブジェクトとしている
+  @Post('create-pdca/:id/:round')
   async createPDCA(
-    @Param('cycleId', ParseIntPipe) cycleId: number,
+    @Param('id', ParseIntPipe) id: number,
     @Param('round', ParseIntPipe) round: number,
-  ): Promise<void> {
-    Promise.all([
-      this.plansService.createPlan(cycleId, round),
-      this.dosService.createDo(cycleId, round),
-      this.checksService.createCheck(cycleId, round),
-      this.actionsService.createAction(cycleId, round),
+  ): Promise<{ round: number }> {
+    await Promise.all([
+      this.plansService.createPlan(id, round),
+      this.dosService.createDo(id, round),
+      this.checksService.createCheck(id, round),
+      this.actionsService.createAction(id, round),
     ]);
+    return { round };
   }
 
+  // サイクルを更新する処理
   @Put('update/:id/:userId')
   async update(
     @Param('id', ParseIntPipe) id: number,
     @Param('userId', ParseIntPipe) userId: number,
     @Body() cycleDtoEdit: CycleDtoEdit,
-  ): Promise<void> {
+  ): Promise<Cycle> {
     return await this.cyclesService.update(id, userId, cycleDtoEdit);
   }
 
@@ -84,16 +89,20 @@ export class CyclesController {
   async erase(
     @Param('id', ParseIntPipe) id: number,
     @Param('userId', ParseIntPipe) userId: number,
-  ) {
+  ): Promise<{
+    erased: boolean;
+  }> {
     return await this.cyclesService.eraseOrRestore(id, userId);
   }
 
-  // 消去されたサイクルを復元する(erasedをfalseに変更する)処理
+  // サイクルをお気に入りに登録する処理
   @Put('favorite/:id/:userId')
   async favorite(
     @Param('id', ParseIntPipe) id: number,
     @Param('userId', ParseIntPipe) userId: number,
-  ) {
+  ): Promise<{
+    favorite: boolean;
+  }> {
     return await this.cyclesService.favorite(id, userId);
   }
 
@@ -102,7 +111,7 @@ export class CyclesController {
   async delete(
     @Param('id', ParseIntPipe) id: number,
     @Param('userId', ParseIntPipe) userId: number,
-  ) {
+  ): Promise<void> {
     return await this.cyclesService.delete(id, userId);
   }
 }

--- a/api/nest_app/src/cycles/cycles.service.ts
+++ b/api/nest_app/src/cycles/cycles.service.ts
@@ -62,11 +62,12 @@ export class CyclesService {
   async eraseOrRestore(
     id: number,
     userId: number,
+    erased: boolean,
   ): Promise<{ erased: boolean }> {
     const cycle = await this.findById(id, userId); //指定のサイクルの存在確認
     const updatedCycle = await this.prisma.cycle.update({
       where: { id: id },
-      data: { erased: !cycle.erased },
+      data: { erased: erased },
     });
     return { erased: updatedCycle.erased };
   }
@@ -79,14 +80,18 @@ export class CyclesService {
   }
 
   // サイクルをお気に入りする処理(付ける/外す両方対応)
-  async favorite(id: number, userId: number): Promise<{ favorite: boolean }> {
+  async favorite(
+    id: number,
+    userId: number,
+    favorite: boolean,
+  ): Promise<{ favorite: boolean }> {
     const cycle = await this.findById(id, userId); //指定のサイクルの存在確認
     if (cycle.erased == true) {
       throw new ForbiddenException('そのサイクルはすでに消去されています。');
     }
     const updatedCycle = await this.prisma.cycle.update({
       where: { id: id },
-      data: { favorite: !cycle.favorite },
+      data: { favorite: favorite },
     });
     return { favorite: updatedCycle.favorite };
   }

--- a/api/nest_app/src/cycles/cycles.service.ts
+++ b/api/nest_app/src/cycles/cycles.service.ts
@@ -36,34 +36,39 @@ export class CyclesService {
     return cycle;
   }
 
-  async create(cycleDto: CycleDto): Promise<void> {
-    await this.prisma.cycle.create({
+  async create(cycleDto: CycleDto): Promise<Cycle> {
+    const createdCycle = await this.prisma.cycle.create({
       data: cycleDto,
     });
+    return createdCycle;
   }
 
   async update(
     id: number,
     userId: number,
     cycleDtoEdit: CycleDtoEdit,
-  ): Promise<void> {
+  ): Promise<Cycle> {
     const cycle = await this.findById(id, userId); //指定のサイクルの存在確認
     if (cycle.erased == true) {
       throw new ForbiddenException('そのサイクルは消去されています。');
     }
-    await this.prisma.cycle.update({
+    return await this.prisma.cycle.update({
       where: { id: id },
       data: cycleDtoEdit,
     });
   }
 
   // サイクルを消去する/復元する処理(erasedを変更する)処理
-  async eraseOrRestore(id: number, userId: number): Promise<void> {
+  async eraseOrRestore(
+    id: number,
+    userId: number,
+  ): Promise<{ erased: boolean }> {
     const cycle = await this.findById(id, userId); //指定のサイクルの存在確認
-    await this.prisma.cycle.update({
+    const updatedCycle = await this.prisma.cycle.update({
       where: { id: id },
       data: { erased: !cycle.erased },
     });
+    return { erased: updatedCycle.erased };
   }
 
   // 消去されたサイクル一覧を取得
@@ -74,15 +79,16 @@ export class CyclesService {
   }
 
   // サイクルをお気に入りする処理(付ける/外す両方対応)
-  async favorite(id: number, userId: number): Promise<void> {
+  async favorite(id: number, userId: number): Promise<{ favorite: boolean }> {
     const cycle = await this.findById(id, userId); //指定のサイクルの存在確認
     if (cycle.erased == true) {
       throw new ForbiddenException('そのサイクルはすでに消去されています。');
     }
-    await this.prisma.cycle.update({
+    const updatedCycle = await this.prisma.cycle.update({
       where: { id: id },
       data: { favorite: !cycle.favorite },
     });
+    return { favorite: updatedCycle.favorite };
   }
 
   async delete(id: number, userId: number): Promise<void> {

--- a/api/nest_app/src/dos/dos.controller.ts
+++ b/api/nest_app/src/dos/dos.controller.ts
@@ -27,7 +27,7 @@ export class DosController {
     @Param('cycleId', ParseIntPipe) cycleId: number,
     @Param('round', ParseIntPipe) round: number,
     @Body('complete', ParseBoolPipe) complete: boolean,
-  ): Promise<void> {
-    await this.dosService.updateComplete(cycleId, round, complete);
+  ): Promise<{ complete: boolean }> {
+    return await this.dosService.updateComplete(cycleId, round, complete);
   }
 }

--- a/api/nest_app/src/dos/dos.service.ts
+++ b/api/nest_app/src/dos/dos.service.ts
@@ -10,8 +10,8 @@ export class DosService {
     return await this.prisma.do.findFirst({ where: { cycleId, round } });
   }
 
-  async createDo(cycleId: number, round: number): Promise<void> {
-    await this.prisma.do.create({
+  async createDo(cycleId: number, round: number): Promise<Do> {
+    return await this.prisma.do.create({
       data: {
         cycleId,
         round,
@@ -23,10 +23,13 @@ export class DosService {
     cycleId: number,
     round: number,
     complete: boolean,
-  ): Promise<void> {
+  ): Promise<{ complete: boolean }> {
     await this.prisma.do.updateMany({
       where: { cycleId, round },
       data: { complete },
     });
+    return {
+      complete: (await this.findDo(cycleId, round)).complete,
+    };
   }
 }

--- a/api/nest_app/src/dos/dos.service.ts
+++ b/api/nest_app/src/dos/dos.service.ts
@@ -29,7 +29,7 @@ export class DosService {
       data: { complete },
     });
     return {
-      complete: (await this.findDo(cycleId, round)).complete,
+      complete: complete,
     };
   }
 }

--- a/api/nest_app/src/plans/plans.controller.ts
+++ b/api/nest_app/src/plans/plans.controller.ts
@@ -30,12 +30,12 @@ export class PlansController {
   }
 
   @Put('update/:cycleId/:round')
-  async updateDate(
+  async update(
     @Param('cycleId', ParseIntPipe) cycleId: number,
     @Param('round', ParseIntPipe) round: number,
     @Body('goalInRound') goalInRound: string,
-  ): Promise<void> {
-    await this.plansService.update(cycleId, round, goalInRound);
+  ): Promise<Plan> {
+    return await this.plansService.update(cycleId, round, goalInRound);
   }
 
   @Put('update-complete/:cycleId/:round')
@@ -43,7 +43,9 @@ export class PlansController {
     @Param('cycleId', ParseIntPipe) cycleId: number,
     @Param('round', ParseIntPipe) round: number,
     @Body('complete', ParseBoolPipe) complete: boolean,
-  ): Promise<void> {
-    await this.plansService.updateComplete(cycleId, round, complete);
+  ): Promise<{
+    complete: boolean;
+  }> {
+    return await this.plansService.updateComplete(cycleId, round, complete);
   }
 }

--- a/api/nest_app/src/plans/plans.service.ts
+++ b/api/nest_app/src/plans/plans.service.ts
@@ -26,8 +26,8 @@ export class PlansService {
     return latestRound;
   }
 
-  async createPlan(cycleId: number, round: number): Promise<void> {
-    await this.prisma.plan.create({
+  async createPlan(cycleId: number, round: number): Promise<Plan> {
+    return await this.prisma.plan.create({
       data: {
         cycleId,
         round,
@@ -39,23 +39,27 @@ export class PlansService {
     cycleId: number,
     round: number,
     goalInRound: string,
-  ): Promise<void> {
+  ): Promise<Plan> {
     await this.prisma.plan.updateMany({
       where: { cycleId, round },
       data: {
         goalInRound,
       },
     });
+    return await this.findPlan(cycleId, round);
   }
 
   async updateComplete(
     cycleId: number,
     round: number,
     complete: boolean,
-  ): Promise<void> {
+  ): Promise<{ complete: boolean }> {
     await this.prisma.plan.updateMany({
       where: { cycleId, round },
       data: { complete },
     });
+    return {
+      complete: (await this.findPlan(cycleId, round)).complete,
+    };
   }
 }

--- a/api/nest_app/src/plans/plans.service.ts
+++ b/api/nest_app/src/plans/plans.service.ts
@@ -59,7 +59,7 @@ export class PlansService {
       data: { complete },
     });
     return {
-      complete: (await this.findPlan(cycleId, round)).complete,
+      complete: complete,
     };
   }
 }

--- a/api/nest_app/src/tasks/tasks.controller.ts
+++ b/api/nest_app/src/tasks/tasks.controller.ts
@@ -4,6 +4,7 @@ import {
   Delete,
   Get,
   Param,
+  ParseBoolPipe,
   ParseIntPipe,
   Post,
   Put,
@@ -34,21 +35,24 @@ export class TasksController {
     @Param('cycleId', ParseIntPipe) cycleId: number,
     @Param('round', ParseIntPipe) round: number,
     @Body() taskDto: TaskDto,
-  ): Promise<void> {
-    await this.tasksService.create(cycleId, round, taskDto);
+  ): Promise<Task> {
+    return await this.tasksService.create(cycleId, round, taskDto);
   }
 
   @Put('update-complete/:id')
-  async updateComplete(@Param('id', ParseIntPipe) id: number): Promise<void> {
-    await this.tasksService.updateComplete(id);
+  async updateComplete(
+    @Param('id', ParseIntPipe) id: number,
+    @Body('complete', ParseBoolPipe) complete: boolean,
+  ): Promise<{ complete: boolean }> {
+    return await this.tasksService.updateComplete(id, complete);
   }
 
   @Put('update/:id')
   async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() taskDto: TaskDto,
-  ): Promise<void> {
-    await this.tasksService.update(id, taskDto);
+  ): Promise<Task> {
+    return await this.tasksService.update(id, taskDto);
   }
 
   @Delete(':id')

--- a/api/nest_app/src/tasks/tasks.service.ts
+++ b/api/nest_app/src/tasks/tasks.service.ts
@@ -19,21 +19,27 @@ export class TasksService {
     cycleId: number,
     round: number,
     taskDto: TaskDto,
-  ): Promise<void> {
-    await this.prisma.task.create({ data: { cycleId, round, ...taskDto } });
-  }
-
-  async update(id: number, taskDto: TaskDto): Promise<void> {
-    const task = await this.findById(id);
-    await this.prisma.task.update({ where: { id }, data: taskDto });
-  }
-
-  async updateComplete(id: number): Promise<void> {
-    const task = await this.findById(id);
-    await this.prisma.task.update({
-      where: { id },
-      data: { complete: !task.complete },
+  ): Promise<Task> {
+    return await this.prisma.task.create({
+      data: { cycleId, round, ...taskDto },
     });
+  }
+
+  async update(id: number, taskDto: TaskDto): Promise<Task> {
+    const task = await this.findById(id);
+    return await this.prisma.task.update({ where: { id }, data: taskDto });
+  }
+
+  async updateComplete(
+    id: number,
+    complete: boolean,
+  ): Promise<{ complete: boolean }> {
+    const task = await this.findById(id);
+    const updatedTask = await this.prisma.task.update({
+      where: { id },
+      data: { complete: complete },
+    });
+    return { complete: updatedTask.complete };
   }
 
   async delete(id: number): Promise<void> {


### PR DESCRIPTION
apiのcreate, updateの処理において、以前までは返り値を返さない仕様だったのだが、返り値を返すように改修した。
理由としては、front側でその返り値をもとにstateを再設定することができ、コードの簡略化につながると考えたから。